### PR TITLE
Remember and restore collapsed code blocks via localStorage

### DIFF
--- a/main.js
+++ b/main.js
@@ -156,19 +156,29 @@ $(function() {
     try {
       if (localStorage.getItem(STORAGE_ID) !== null) {
         let storage = getStorage();
+        let storageLength = storage.length;
+        let passed = true;
+        let collapsed = [];
 
-        storage.forEach(function(item) {
-          let [lower, upper] = item.key.split('-');
-          upper++;
-          let lowerLine = document.querySelector('#LC' + lower).textContent;
-          let upperLine = document.querySelector('#LC' + upper).textContent;
+        for (let i = 0; i < storageLength; i++) {
+          let [lower, upper] = storage[i].key.split('-');
+          let lowerLine = lower - 1;
 
-          if (lowerLine.includes('{') && upperLine.includes('}')) {
-            document.querySelector('#LC' + lower + ' .collapser').click();
+          if (pairs.get(lowerLine) == upper) {
+            collapsed.push(lower);
           } else {
-            localStorage.removeItem(STORAGE_ID);
+            passed = false;
+            break;
           }
-        });
+        }
+
+        if (passed) {
+          collapsed.forEach(function(line) {
+            document.querySelector('#LC' + line + ' .collapser').click();
+          });
+        } else {
+          localStorage.removeItem(STORAGE_ID);
+        }
       }
     } catch(err) {
       return false;

--- a/main.js
+++ b/main.js
@@ -158,7 +158,16 @@ $(function() {
         let storage = getStorage();
 
         storage.forEach(function(item) {
-          document.querySelector('#LC' + item.key.split('-')[0] + ' .collapser').click();
+          let [lower, upper] = item.key.split('-');
+          upper++;
+          let lowerLine = document.querySelector('#LC' + lower).textContent;
+          let upperLine = document.querySelector('#LC' + upper).textContent;
+
+          if (lowerLine.includes('{') && upperLine.includes('}')) {
+            document.querySelector('#LC' + lower + ' .collapser').click();
+          } else {
+            localStorage.removeItem(STORAGE_ID);
+          }
         });
       }
     } catch(err) {

--- a/main.js
+++ b/main.js
@@ -152,7 +152,7 @@ $(function() {
     setStorage(storage);
   }
 
-  (function collapseItemsOnload() {
+  function collapseRanges() {
     try {
       if (localStorage.getItem(STORAGE_ID) !== null) {
         let storage = getStorage();
@@ -184,5 +184,7 @@ $(function() {
       return false;
     }
     hasLoaded = true;
-  })();
+  }
+
+  $(document).ready(collapseRanges);
 });


### PR DESCRIPTION
Hi Noam,

I'm that guy from Twitter who suggested the `localStorage` feature. The idea is simple, that it would be cool if a user's choice was remembered across all visited GitHub pages.

A few notes:

- I chose to store only the hidden ranges for less memory consumption. Each different GitHub page is a key, and each line range is a value.
- I noticed if users collapse a range and then collapse a parent range surrounding that child range (can be multiple), the collapsed child range is automatically expanded when the parent is expanded. This was the trickiest part to deal with but it's working now. For example, if a user collapses blocks 10-12 and 14-16 and then collapses a surrounding block (say, lines 5-20), those inner ranges will be immediately deleted from `localStorage`.
- Double ellipses(... ...) were being added to hidden blocks on page load, so I added a condition around that part of the code to defend against that happening.
- The `try/catch` was used to protect against users in Safari private browsing mode. In this case, `localStorage` appears to be available, though it will not work and will throw an error.