### PR TITLE
Don't expand previously closed inner blocks

### DIFF
--- a/.prettierrc.yml
+++ b/.prettierrc.yml
@@ -1,0 +1,6 @@
+printWidth: 120
+tabWidth: 4
+singleQuote: true
+tralingComma: 'all'
+semi: true
+endOfLine: 'auto'

--- a/background.js
+++ b/background.js
@@ -1,9 +1,9 @@
 
 chrome.tabs.onUpdated.addListener((tabId, changeinfo) => {
-  if (changeinfo.status === "complete") {
-    chrome.scripting.executeScript({
-      target: { tabId },
-      files: ["main.js"],
-    });
-  }
+    if (changeinfo.status === 'complete') {
+        chrome.scripting.executeScript({
+            target: { tabId },
+            files: ['main.js'],
+        });
+    }
 });

--- a/background.js
+++ b/background.js
@@ -1,4 +1,3 @@
-
 chrome.tabs.onUpdated.addListener((tabId, changeinfo) => {
     if (changeinfo.status === 'complete') {
         chrome.scripting.executeScript({

--- a/main.js
+++ b/main.js
@@ -19,8 +19,12 @@
         el.parentElement.removeChild(el);
     });
 
+    document.querySelectorAll('.' + classes.hidden).forEach((el) => {
+        el.classList.remove(classes.hidden);
+    });
+
     document.querySelectorAll(`[${classes.previouslyCollapsed}]`).forEach((el) => {
-        el.removeAttribute(`[${classes.previouslyCollapsed}]`);
+        el.removeAttribute(classes.previouslyCollapsed);
     });
 
     const codeLines = [...document.querySelectorAll('table.js-file-line-container tr .blob-code-inner')];
@@ -56,7 +60,7 @@
     };
 
     const ellipsisFactory = (id) => {
-        return new Element('span').addClass('pl-smi').addClass(classes.ellipsis).setId(id).setHTML('...').element;
+        return new Element('span').addClass(classes.ellipsis).setId(id).setHTML('...').element;
     };
 
     const spaceMap = new Map();

--- a/main.js
+++ b/main.js
@@ -2,15 +2,25 @@
     'use strict';
 
     const classes = {
-        hidden: 'hidden-line',
-        sideways: 'sideways',
-        collapser: 'collapser',
-        ellipsis: 'ellipsis',
-        previouslyCollapsed: 'stay-hidden',
+        hidden: 'gcf-hidden-line',
+        sideways: 'gcf-sideways',
+        collapser: 'gcf-collapser',
+        ellipsis: 'gcf-ellipsis',
+        blockStart: 'gcf-block-start',
+        previouslyCollapsed: 'gcf-stay-hidden',
     };
 
-    [...document.querySelectorAll('.' + classes.collapser)].forEach((arrow) => {
+    // Clear old classes and attributes from previous page loads
+    document.querySelectorAll('.' + classes.collapser).forEach((arrow) => {
         arrow.parentElement.removeChild(arrow);
+    });
+
+    document.querySelectorAll('.' + classes.ellipsis).forEach((el) => {
+        el.parentElement.removeChild(el);
+    });
+
+    document.querySelectorAll(`[${classes.previouslyCollapsed}]`).forEach((el) => {
+        el.removeAttribute(`[${classes.previouslyCollapsed}]`);
     });
 
     const codeLines = [...document.querySelectorAll('table.js-file-line-container tr .blob-code-inner')];
@@ -79,7 +89,7 @@
             let top = last(stack);
             if (count !== -1 && count <= spaceMap.get(top)) {
                 pairs.set(top, lineNum);
-                codeLines[top].setAttribute('block-start', 'true');
+                // codeLines[top].setAttribute(classes.blockStart, true);
                 const arrow = arrowFactory(`gcf-${top + 1}`);
                 codeLines[top].prepend(arrow);
                 blockStarts.push(codeLines[top]);

--- a/main.js
+++ b/main.js
@@ -1,175 +1,165 @@
 (function () {
-  "use strict";
+    'use strict';
 
-  [...document.querySelectorAll('.collapser')].forEach(arrow => {
-    arrow.parentElement.removeChild(arrow);
-  });
-
-  const codeLines = [
-    ...document.querySelectorAll(
-      "table.js-file-line-container tr .blob-code-inner"
-    ),
-  ];
-  const codeLinesText = codeLines.map((l) => l.textContent);
-
-  const _arrow =
-    '<svg version="1.1" width="7px" fill="#969896" xmlns="http://www.w3.org/2000/svg" ' +
-    'xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="0 0 1000 1000" enable-background="new 0 0 1000 1000" xml:space="preserve">' +
-    "<metadata> Svg Vector Icons : http://www.onlinewebfonts.com/icon </metadata>" +
-    '<g><path d="M579.5,879.8c-43.7,75.7-115.3,75.7-159,0L28.7,201.1c-43.7-75.7-8-137.7,79.5-137.7h783.7c87.5,0,123.2,62,79.5,137.7L579.5,879.8z"></path></g>' +
-    "</svg>";
-
-
-  class Element {
-    constructor(name) {
-      this.element = document.createElement(name);
-    }
-    addClass(className) {
-      this.element.classList.add(className);
-      return this;
-    }
-    setId(id) {
-      this.element.id = id;
-      return this;
-    }
-    setHTML(str) {
-      this.element.innerHTML = str;
-      return this;
-    }
-  }
-
-  const arrowFactory = (id) => {
-    return new Element("span").addClass("collapser").setId(id).setHTML(_arrow)
-      .element;
-  };
-
-  const ellipsisFactory = (id) => {
-    return new Element("span")
-      .addClass("pl-smi")
-      .addClass("ellipsis")
-      .setId(id)
-      .setHTML("...").element;
-  };
-
-  const spaceMap = new Map();
-  const pairs = new Map();
-  const stack = [];
-  const blockStarts = [];
-  const countLeadingWhitespace = (arr) => {
-    const getWhitespaceIndex = (i) => {
-      if (arr[i] !== " " && arr[i] !== "\t") {
-        return i;
-      }
-      i++;
-      return getWhitespaceIndex(i);
+    const classes = {
+        hidden: 'hidden-line',
+        sideways: 'sideways',
+        collapser: 'collapser',
+        ellipsis: 'ellipsis',
+        previouslyCollapsed: 'stay-hidden',
     };
-    return getWhitespaceIndex(0);
-  };
 
-  const last = (arr) => arr[arr.length - 1];
-  const getPreviousSpaces = (map, lineNum) => {
-    let prev = map.get(lineNum - 1);
-    return prev === -1
-      ? getPreviousSpaces(map, lineNum - 1)
-      : { lineNum: lineNum - 1, count: prev };
-  };
+    [...document.querySelectorAll('.' + classes.collapser)].forEach((arrow) => {
+        arrow.parentElement.removeChild(arrow);
+    });
 
-  for (let lineNum = 0; lineNum < codeLinesText.length; lineNum++) {
-    let line = codeLinesText[lineNum];
-    let count = line.trim().length
-      ? countLeadingWhitespace(line.split(""))
-      : -1;
-    spaceMap.set(lineNum, count);
+    const codeLines = [...document.querySelectorAll('table.js-file-line-container tr .blob-code-inner')];
+    const codeLinesText = codeLines.map((l) => l.textContent);
 
-    function tryPair() {
-      let top = last(stack);
-      if (count !== -1 && count <= spaceMap.get(top)) {
-        pairs.set(top, lineNum);
-        codeLines[top].setAttribute("block-start", "true");
-        const arrow = arrowFactory(`gcf-${top + 1}`);
-        codeLines[top].appendChild(arrow);
-        blockStarts.push(codeLines[top]);
-        stack.pop();
-        return tryPair();
-      }
-    }
-    tryPair();
+    const _arrow =
+        '<svg version="1.1" width="7px" fill="#969896" xmlns="http://www.w3.org/2000/svg" ' +
+        'xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="0 0 1000 1000" enable-background="new 0 0 1000 1000" xml:space="preserve">' +
+        '<metadata> Svg Vector Icons : http://www.onlinewebfonts.com/icon </metadata>' +
+        '<g><path d="M579.5,879.8c-43.7,75.7-115.3,75.7-159,0L28.7,201.1c-43.7-75.7-8-137.7,79.5-137.7h783.7c87.5,0,123.2,62,79.5,137.7L579.5,879.8z"></path></g>' +
+        '</svg>';
 
-    let prevSpaces = getPreviousSpaces(spaceMap, lineNum);
-    if (count > prevSpaces.count) {
-      stack.push(prevSpaces.lineNum);
-    }
-  }
-
-  const toggleCode = (action, start, end) => {
-    if (action === "hide") {
-      const sliced = codeLines.slice(start, end);
-      sliced.forEach((elem) => {
-        let tr = elem.parentNode;
-        if (tr.classList) {
-          tr.classList.add("hidden-line");
-        } else {
-          tr.className += " hidden-line";
+    class Element {
+        constructor(name) {
+            this.element = document.createElement(name);
         }
-        // Check if any children blocks of this parent block have previously
-        // been collapsed so we can remove ellipsis and reset arrows
-        let previouslyCollapsed = elem.querySelectorAll(".ellipsis");
-        previouslyCollapsed.forEach((block) => {
-          block.previousSibling.classList.remove("sideways");
-          block.parentNode.removeChild(block);
-        });
-      });
-      codeLines[start - 1].appendChild(
-        ellipsisFactory(`ellipsis-${start - 1}`)
-      );
-    } else if (action === "show") {
-      const sliced = codeLines.slice(start, end);
-      const topLine = codeLines[start - 1];
-      sliced.forEach((elem) => {
-        let tr = elem.parentNode;
-        if (tr.classList) {
-          tr.classList.remove("hidden-line");
-        } else {
-          tr.className.replace(" hidden-line", "");
+        addClass(className) {
+            this.element.classList.add(className);
+            return this;
         }
-      });
-      topLine.removeChild(topLine.lastChild);
+        setId(id) {
+            this.element.id = id;
+            return this;
+        }
+        setHTML(str) {
+            this.element.innerHTML = str;
+            return this;
+        }
     }
-  };
 
-  const arrows = document.querySelectorAll(".collapser");
-  function arrowListener(e) {
-    e.preventDefault();
-    let svg = e.currentTarget;
-    let td = e.currentTarget.parentElement;
-    let id = td.getAttribute("id");
-    let index = parseInt(id.slice(2)) - 1;
-    if (svg.classList.contains("sideways")) {
-      svg.classList.remove("sideways");
-      toggleCode("show", index + 1, pairs.get(index));
-    } else {
-      svg.classList.add("sideways");
-      toggleCode("hide", index + 1, pairs.get(index));
+    const arrowFactory = (id) => {
+        return new Element('span').addClass(classes.collapser).setId(id).setHTML(_arrow).element;
+    };
+
+    const ellipsisFactory = (id) => {
+        return new Element('span').addClass('pl-smi').addClass(classes.ellipsis).setId(id).setHTML('...').element;
+    };
+
+    const spaceMap = new Map();
+    const pairs = new Map();
+    const stack = [];
+    const blockStarts = [];
+    const countLeadingWhitespace = (arr) => {
+        const getWhitespaceIndex = (i) => {
+            if (arr[i] !== ' ' && arr[i] !== '\t') {
+                return i;
+            }
+            i++;
+            return getWhitespaceIndex(i);
+        };
+        return getWhitespaceIndex(0);
+    };
+
+    const last = (arr) => arr[arr.length - 1];
+    const getPreviousSpaces = (map, lineNum) => {
+        let prev = map.get(lineNum - 1);
+        return prev === -1 ? getPreviousSpaces(map, lineNum - 1) : { lineNum: lineNum - 1, count: prev };
+    };
+
+    for (let lineNum = 0; lineNum < codeLinesText.length; lineNum++) {
+        let line = codeLinesText[lineNum];
+        let count = line.trim().length ? countLeadingWhitespace(line.split('')) : -1;
+        spaceMap.set(lineNum, count);
+
+        function tryPair() {
+            let top = last(stack);
+            if (count !== -1 && count <= spaceMap.get(top)) {
+                pairs.set(top, lineNum);
+                codeLines[top].setAttribute('block-start', 'true');
+                const arrow = arrowFactory(`gcf-${top + 1}`);
+                codeLines[top].prepend(arrow);
+                blockStarts.push(codeLines[top]);
+                stack.pop();
+                return tryPair();
+            }
+        }
+        tryPair();
+
+        let prevSpaces = getPreviousSpaces(spaceMap, lineNum);
+        if (count > prevSpaces.count) {
+            stack.push(prevSpaces.lineNum);
+        }
     }
-  }
 
-  arrows.forEach((c) => {
-    c.addEventListener("click", arrowListener);
-  });
+    const toggleCode = (action, start, end) => {
+        if (action === 'hide') {
+            const sliced = codeLines.slice(start, end);
+            sliced.forEach((elem) => {
+                const tr = elem.parentElement;
 
-  function ellipsisListener(e) {
-    if (!e.target.parentElement) return;
-    if (e.target.classList.contains("ellipsis")) {
-      let td = e.target.parentElement;
-      let svg = td.querySelector(".sideways");
-      let id = e.target.parentElement.getAttribute("id");
-      let index = parseInt(id.slice(2)) - 1;
-      svg.classList.remove("sideways");
-      toggleCode("show", index + 1, pairs.get(index));
+                // If a line was already hidden, there was an inner block that
+                // was previously collapsed. Setting this attribute will
+                // protect the inner block from being expanded
+                // when this current outer block is expanded
+                if (tr.classList.contains(classes.hidden)) {
+                    tr.setAttribute(classes.previouslyCollapsed, true);
+                }
+                tr.classList.add(classes.hidden);
+            });
+            codeLines[start - 1].appendChild(ellipsisFactory(`ellipsis-${start - 1}`));
+        } else if (action === 'show') {
+            const sliced = codeLines.slice(start, end);
+            const topLine = codeLines[start - 1];
+
+            sliced.forEach((elem) => {
+                const tr = elem.parentElement;
+                if (!tr.getAttribute(classes.previouslyCollapsed)) {
+                    tr.classList.remove(classes.hidden);
+                } else {
+                    tr.removeAttribute(classes.previouslyCollapsed);
+                }
+            });
+            topLine.removeChild(topLine.lastChild);
+        }
+    };
+
+    const arrows = document.querySelectorAll('.' + classes.collapser);
+    function arrowListener(e) {
+        e.preventDefault();
+        let svg = e.currentTarget;
+        let td = e.currentTarget.parentElement;
+        let id = td.getAttribute('id');
+        let index = parseInt(id.slice(2)) - 1;
+        if (svg.classList.contains(classes.sideways)) {
+            svg.classList.remove(classes.sideways);
+            toggleCode('show', index + 1, pairs.get(index));
+        } else {
+            svg.classList.add(classes.sideways);
+            toggleCode('hide', index + 1, pairs.get(index));
+        }
     }
-  }
 
-  blockStarts.forEach((line) => {
-    line.addEventListener("click", ellipsisListener);
-  });
+    arrows.forEach((c) => {
+        c.addEventListener('click', arrowListener);
+    });
+
+    function ellipsisListener(e) {
+        if (!e.target.parentElement) return;
+        if (e.target.classList.contains(classes.ellipsis)) {
+            let td = e.target.parentElement;
+            let svg = td.querySelector('.' + classes.sideways);
+            let id = e.target.parentElement.getAttribute('id');
+            let index = parseInt(id.slice(2)) - 1;
+            svg.classList.remove(classes.sideways);
+            toggleCode('show', index + 1, pairs.get(index));
+        }
+    }
+
+    blockStarts.forEach((line) => {
+        line.addEventListener('click', ellipsisListener);
+    });
 })();

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "GitHub Code Folding",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Enable code folding when viewing files in GitHub.",
   "homepage_url": "https://github.com/noam3127/github-code-folding",
   "manifest_version": 3,

--- a/style.css
+++ b/style.css
@@ -2,8 +2,9 @@ td.blob-code.blob-code-inner {
   padding-left: 13px;
 }
 .collapser {
-  margin-left: -12px;
-  margin-right: 6px;
+  margin-left: -16px;
+  margin-right: 2px;
+  padding-right: 6px;
   opacity: 0.5;
 }
 

--- a/style.css
+++ b/style.css
@@ -1,38 +1,38 @@
 td.blob-code.blob-code-inner {
-  padding-left: 13px;
+    padding-left: 13px;
 }
-.collapser {
-  margin-left: -16px;
-  margin-right: 2px;
-  padding-right: 6px;
-  opacity: 0.5;
-}
-
-.collapser:hover {
-  opacity: 1;
+.gcf-collapser {
+    margin-left: -16px;
+    margin-right: 2px;
+    padding-right: 6px;
+    opacity: 0.5;
 }
 
-.collapser > svg {
-  transition: 0.15s ease-in-out;
+.gcf-collapser:hover {
+    opacity: 1;
 }
 
-.sideways > svg {
-  transform: rotate(-90deg);
-  transform-origin: center;
-  opacity: 0.8;
+.gcf-collapser > svg {
+    transition: 0.15s ease-in-out;
 }
 
-.hidden-line {
-  display: none;
+.gcf-sideways > svg {
+    transform: rotate(-90deg);
+    transform-origin: center;
+    opacity: 0.8;
 }
 
-.ellipsis {
-  padding: 1px 2px;
-  margin-left: 2px;
-  cursor: pointer;
-  background: rgba(255, 235, 59, 0.4);
+.gcf-hidden-line {
+    display: none;
 }
 
-.ellipsis:hover {
-  background: rgba(255, 235, 59, 0.7);
+.gcf-ellipsis {
+    padding: 1px 2px;
+    margin-left: 2px;
+    cursor: pointer;
+    background: rgba(255, 235, 59, 0.4);
+}
+
+.gcf-ellipsis:hover {
+    background: rgba(255, 235, 59, 0.7);
 }

--- a/style.css
+++ b/style.css
@@ -2,9 +2,8 @@ td.blob-code.blob-code-inner {
   padding-left: 13px;
 }
 .collapser {
-  position: absolute;
-  left: 2px;
-  width: 22px;
+  margin-left: -12px;
+  margin-right: 6px;
   opacity: 0.5;
 }
 


### PR DESCRIPTION
Previously, if an inner block was collapsed followed by collapsing an outer block, when expanding the outer block it would also expand the inner one. This fixes that so the inner block remains collapsed.

Also includes:
- a small bugfix for the arrow positioning which obstructed selecting/copying of code next to it
- small refactor
- prettier
- class and attribute namespaces